### PR TITLE
Added option to control number of decimal places

### DIFF
--- a/gtrend.py
+++ b/gtrend.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 
 
-from datetime import datetime, timedelta, date, time
+from datetime import datetime, timedelta
 import pandas as pd
 import time
 
@@ -11,7 +11,7 @@ from pytrends.exceptions import ResponseError
 
 
 def _fetch_data(trendreq, kw_list, timeframe='today 3-m', cat=0, geo='', gprop='') -> pd.DataFrame:
-    
+
     """Download google trends data using pytrends TrendReq and retries in case of a ResponseError."""
     attempts, fetched = 0, False
     while not fetched:
@@ -20,7 +20,7 @@ def _fetch_data(trendreq, kw_list, timeframe='today 3-m', cat=0, geo='', gprop='
         except ResponseError as err:
             print(err)
             print(f'Trying again in {60 + 5 * attempts} seconds.')
-            sleep(60 + 5 * attempts)
+            time.sleep(60 + 5 * attempts)
             attempts += 1
             if attempts > 3:
                 print('Failed after 3 attemps, abort fetching.')
@@ -29,13 +29,13 @@ def _fetch_data(trendreq, kw_list, timeframe='today 3-m', cat=0, geo='', gprop='
             fetched = True
     return trendreq.interest_over_time()
 
-def get_daily_trend(trendreq, keyword:str, start:str, end:str, cat=0, 
-                    geo='', gprop='', delta=269, overlap=100, sleep=0, 
-                    tz=0, verbose=False) ->pd.DataFrame:
+def get_daily_trend(trendreq, keyword:str, start:str, end:str, cat=0,
+                    geo='', gprop='', delta=269, overlap=100, sleep=0,
+                    tz=0, verbose=False, decimals=0) ->pd.DataFrame:
 
     """Stich and scale consecutive daily trends data between start and end date.
-    This function will first download piece-wise google trends data and then 
-    scale each piece using the overlapped period. 
+    This function will first download piece-wise google trends data and then
+    scale each piece using the overlapped period.
 
         Parameters
         ----------
@@ -47,22 +47,23 @@ def get_daily_trend(trendreq, keyword:str, start:str, end:str, cat=0,
             starting date in string format:YYYY-MM-DD (e.g.2017-02-19)
         end: str
             ending date in string format:YYYY-MM-DD (e.g.2017-02-19)
-        cat, geo, gprop, sleep: 
+        cat, geo, gprop, sleep:
             same as defined in pytrends
         delta: int
-            The length(days) of each timeframe fragment for fetching google trends data, 
+            The length(days) of each timeframe fragment for fetching google trends data,
             need to be <269 in order to obtain daily data.
         overlap: int
             The length(days) of the overlap period used for scaling/normalization
         tz: int
             The timezone shift in minute relative to the UTC+0 (google trends default).
-            For example, correcting for UTC+8 is 480, and UTC-6 is -360 
-
+            For example, correcting for UTC+8 is 480, and UTC-6 is -360
+        decimals: int
+            The number of decimals to use when rounding the output. Default is 0
     """
-    
+
     start_d = datetime.strptime(start, '%Y-%m-%d')
     init_end_d = end_d = datetime.strptime(end, '%Y-%m-%d')
-    init_end_d.replace(hour=23, minute=59, second=59)    
+    init_end_d.replace(hour=23, minute=59, second=59)
     delta = timedelta(days=delta)
     overlap = timedelta(days=overlap)
 
@@ -71,7 +72,7 @@ def get_daily_trend(trendreq, keyword:str, start:str, end:str, cat=0,
 
     df = pd.DataFrame()
     ol = pd.DataFrame()
-    
+
     while end_d > start_d:
         tf = itr_d.strftime('%Y-%m-%d')+' '+end_d.strftime('%Y-%m-%d')
         if verbose: print('Fetching \''+keyword+'\' for period:'+tf)
@@ -87,7 +88,7 @@ def get_daily_trend(trendreq, keyword:str, start:str, end:str, cat=0,
             y2 = df.loc[overlap_start:end_d].iloc[:,-1].values.max()
             coef = y2/y1
             temp = temp * coef
-            ol_temp.loc[overlap_start:end_d, :] = 1 
+            ol_temp.loc[overlap_start:end_d, :] = 1
 
         df = pd.concat([df,temp], axis=1)
         ol = pd.concat([ol, ol_temp], axis=1)
@@ -97,26 +98,26 @@ def get_daily_trend(trendreq, keyword:str, start:str, end:str, cat=0,
         itr_d -= (delta-overlap)
         # in case of short query interval getting banned by server
         time.sleep(sleep)
-    
+
     df.sort_index(inplace=True)
     ol.sort_index(inplace=True)
     #The daily trend data is missing the most recent 3-days data, need to complete with hourly data
-    if df.index.max() < init_end_d : 
+    if df.index.max() < init_end_d :
         tf = 'now 7-d'
         hourly = _fetch_data(trendreq, [keyword], timeframe=tf, cat=cat, geo=geo, gprop=gprop)
         hourly.drop(columns=['isPartial'], inplace=True)
-        
+
         #convert hourly data to daily data
         daily = hourly.groupby(hourly.index.date).sum()
-        
+
         #check whether the first day data is complete (i.e. has 24 hours)
         daily['hours'] = hourly.groupby(hourly.index.date).count()
         if daily.iloc[0].loc['hours'] != 24: daily.drop(daily.index[0], inplace=True)
         daily.drop(columns='hours', inplace=True)
-        
+
         daily.set_index(pd.DatetimeIndex(daily.index), inplace=True)
         daily.columns = [tf]
-        
+
         ol_temp = daily.copy()
         ol_temp.iloc[:,:] = None
         # find the overlapping date
@@ -124,9 +125,9 @@ def get_daily_trend(trendreq, keyword:str, start:str, end:str, cat=0,
         if verbose: print('Normalize by overlapping period:'+(intersect.min().strftime('%Y-%m-%d'))+' '+(intersect.max().strftime('%Y-%m-%d')))
         # scaling use the overlapped today-4 to today-7 data
         coef = df.loc[intersect].iloc[:,0].max() / daily.loc[intersect].iloc[:,0].max()
-        daily = (daily*coef).round(decimals=0)
+        daily = (daily*coef).round(decimals=decimals)
         ol_temp.loc[intersect,:] = 1
-        
+
         df = pd.concat([daily, df], axis=1)
         ol = pd.concat([ol_temp, ol], axis=1)
 
@@ -140,8 +141,6 @@ def get_daily_trend(trendreq, keyword:str, start:str, end:str, cat=0,
     df.index = df.index + timedelta(minutes=tz)
     df = df[start_d:init_end_d]
     # re-normalized to the overall maximum value to have max =100
-    df[keyword] = (100*df[keyword]/df[keyword].max()).round(decimals=0)
-    
+    df[keyword] = (100*df[keyword]/df[keyword].max()).round(decimals=decimals)
+
     return df
-
-


### PR DESCRIPTION
For long histories the distant past may have very small values, which are too coarsely truncated to zero decimal places. I've added an option to allow the user to specify the precision directly.

To be fair, I would just return the dataframe as-is without any rounding, but this would keep backwards-compatibility. 

There was also a bug where `time` was imported twice under different context, and `sleep` was undefined.